### PR TITLE
expand synapse login functionality to accept secrets

### DIFF
--- a/synapsemonitor/__main__.py
+++ b/synapsemonitor/__main__.py
@@ -134,23 +134,6 @@ def build_parser():
     return parser
 
 
-def get_auth_token() -> str:
-    """Get Synapse personal access token from environmental
-    variables, if available.
-
-    Returns:
-        str: Synapse personal access token or None
-    """
-    auth_token = None
-    if os.getenv("SYNAPSE_AUTH_TOKEN") is not None:
-        auth_token = os.getenv("SYNAPSE_AUTH_TOKEN")
-    elif os.getenv("SCHEDULED_JOB_SECRETS") is not None:
-        secrets = json.loads(os.getenv("SCHEDULED_JOB_SECRETS"))
-        auth_token = secrets["SYNAPSE_AUTH_TOKEN"]
-
-    return auth_token
-
-
 def synapse_login(synapse_config=synapseclient.client.CONFIG_FILE):
     """Login to Synapse.  Looks for Synapse credentials in the following order:
     (1) SYNAPSE_AUTH_TOKEN environmental variable
@@ -167,9 +150,9 @@ def synapse_login(synapse_config=synapseclient.client.CONFIG_FILE):
     """
     try:
         syn = synapseclient.Synapse(skip_checks=True, configPath=synapse_config)
-        auth_token = get_auth_token()
-        if auth_token is not None:
-            syn.login(silent=True, authToken=auth_token)
+        if os.getenv("SCHEDULED_JOB_SECRETS") is not None:
+            secrets = json.loads(os.getenv("SCHEDULED_JOB_SECRETS"))
+            syn.login(silent=True, authToken=secrets["SYNAPSE_AUTH_TOKEN"])
         else:
             syn.login(silent=True)
     except (SynapseNoCredentialsError, SynapseAuthenticationError):

--- a/synapsemonitor/__main__.py
+++ b/synapsemonitor/__main__.py
@@ -136,19 +136,19 @@ def build_parser():
 
 
 def get_auth_token() -> str:
-    """Get Synapse personal access token from environmental 
+    """Get Synapse personal access token from environmental
     variables, if available.
 
     Returns:
         str: Synapse personal access token or None
     """
     auth_token = None
-    if os.getenv("SYNAPSE_AUTH_TOKEN") is not None: 
+    if os.getenv("SYNAPSE_AUTH_TOKEN") is not None:
         auth_token = os.getenv("SYNAPSE_AUTH_TOKEN")
     elif os.getenv("SCHEDULED_JOB_SECRETS") is not None:
-        secrets=json.loads(os.getenv("SCHEDULED_JOB_SECRETS"))
-        auth_token=secrets["SYNAPSE_AUTH_TOKEN"]
-    
+        secrets = json.loads(os.getenv("SCHEDULED_JOB_SECRETS"))
+        auth_token = secrets["SYNAPSE_AUTH_TOKEN"]
+
     return auth_token
 
 
@@ -169,7 +169,7 @@ def synapse_login(synapse_config=synapseclient.client.CONFIG_FILE):
     try:
         syn = synapseclient.Synapse(skip_checks=True, configPath=synapse_config)
         auth_token = get_auth_token()
-        if auth_token is not None: 
+        if auth_token is not None:
             syn.login(silent=True, authToken=auth_token)
         else:
             syn.login(silent=True)

--- a/synapsemonitor/__main__.py
+++ b/synapsemonitor/__main__.py
@@ -135,11 +135,7 @@ def build_parser():
 
 
 def synapse_login(synapse_config=synapseclient.client.CONFIG_FILE):
-    """Login to Synapse.  Looks for Synapse credentials in the following order:
-    (1) SYNAPSE_AUTH_TOKEN environmental variable
-    (2) SCHEDULED_JOB_SECRETS environmental variable (contains SYNAPSE_AUTH_TOKEN
-        in JSON string)
-    (3) configuration file
+    """Login to Synapse.  Looks first for secrets.
 
     Args:
         synapse_config: Path to synapse configuration file.

--- a/synapsemonitor/__main__.py
+++ b/synapsemonitor/__main__.py
@@ -2,10 +2,9 @@
 """Command line client"""
 import argparse
 import logging
-import pandas as pd
-import sys
-import os
 import json
+import os
+import sys
 
 import pandas as pd
 import synapseclient


### PR DESCRIPTION
Fixes #58 

synapse login function now searches for synapse credentials in the following order:
1. SCHEDULED_JOB_SECRETS (+ json parsing for SYNAPSE_AUTH_TOKEN)
2. SYNAPSE_AUTH_TOKEN
3. config file path from function argument