### PR TITLE
allow user to specify time unit

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,7 @@ commands:
 Monitors Synapse entities for modifications and sends an email through the Synapse messaging system to the user specified when modified entities are detected. Prints a list of modified File entities.  If the specified entity is a container (Project or Folder), all descendant File entities are monitored.  If the specified entity is a File View, all contained enties are monitored.  
 
 ```
-usage: synapsemonitor monitor [-h] [--users USERS [USERS ...]] [--output OUTPUT]
-                              [--email_subject EMAIL_SUBJECT] [--days days]
-                              synapse_id
+usage: synapsemonitor monitor [-h] [--users USERS [USERS ...]] [--output OUTPUT] [--email_subject EMAIL_SUBJECT] [--value value] [--unit {day,hour,minute}] synapse_id
 
 positional arguments:
   synapse_id            Synapse ID of entity to be monitored.
@@ -52,13 +50,15 @@ positional arguments:
 optional arguments:
   -h, --help            show this help message and exit
   --users USERS [USERS ...], -u USERS [USERS ...]
-                        User Id or username of individuals to send report. If not specified, defaults to
-                        logged in Synapse user.
+                        User Id or username of individuals to send report. If not specified, defaults to logged in Synapse user.
   --output OUTPUT, -o OUTPUT
                         Output modified entities into this csv file. (default: None)
   --email_subject EMAIL_SUBJECT, -e EMAIL_SUBJECT
                         Sets the subject heading of the email sent out. (default: New Synapse Files)
-  --days days, -d days  Find modifications to File entities in the last N days. (default: 1)
+  --value value, -v value
+                        Find modifications to File entities in the last {value} {unit}. (default: 1)
+  --unit {day,hour,minute}, -t {day,hour,minute}
+                        Find modifications to File entities in the last {value} {unit}. (default: day)
 ```
 
 ### Create File View

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ optional arguments:
                         Sets the subject heading of the email sent out. (default: New Synapse Files)
   --value value, -v value
                         Find modifications to File entities in the last {value} {unit}. (default: 1)
-  --unit {day,hour,minute}, -t {day,hour,minute}
+  --unit {day,hour}, -t {day,hour}
                         Find modifications to File entities in the last {value} {unit}. (default: day)
 ```
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ commands:
 Monitors Synapse entities for modifications and sends an email through the Synapse messaging system to the user specified when modified entities are detected. Prints a list of modified File entities.  If the specified entity is a container (Project or Folder), all descendant File entities are monitored.  If the specified entity is a File View, all contained enties are monitored.  
 
 ```
-usage: synapsemonitor monitor [-h] [--users USERS [USERS ...]] [--output OUTPUT] [--email_subject EMAIL_SUBJECT] [--value value] [--unit {day,hour,minute}] synapse_id
+usage: synapsemonitor monitor [-h] [--users USERS [USERS ...]] [--output OUTPUT] [--email_subject EMAIL_SUBJECT] [--value value] [--unit {day,hour}] synapse_id
 
 positional arguments:
   synapse_id            Synapse ID of entity to be monitored.

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ commands:
 Monitors Synapse entities for modifications and sends an email through the Synapse messaging system to the user specified when modified entities are detected. Prints a list of modified File entities.  If the specified entity is a container (Project or Folder), all descendant File entities are monitored.  If the specified entity is a File View, all contained enties are monitored.  
 
 ```
-usage: synapsemonitor monitor [-h] [--users USERS [USERS ...]] [--output OUTPUT] [--email_subject EMAIL_SUBJECT] [--value value] [--unit {day,hour}] synapse_id
+usage: synapsemonitor monitor [-h] [--users USERS [USERS ...]] [--output OUTPUT] [--email_subject EMAIL_SUBJECT] [--rate rate] synapse_id
 
 positional arguments:
   synapse_id            Synapse ID of entity to be monitored.
@@ -55,10 +55,7 @@ optional arguments:
                         Output modified entities into this csv file. (default: None)
   --email_subject EMAIL_SUBJECT, -e EMAIL_SUBJECT
                         Sets the subject heading of the email sent out. (default: New Synapse Files)
-  --value value, -v value
-                        Find modifications to File entities in the last {value} {unit}. (default: 1)
-  --unit {day,hour}, -t {day,hour}
-                        Find modifications to File entities in the last {value} {unit}. (default: day)
+  --rate rate, -r rate  Find modifications to File entities in the last {value} {unit}. (default: '1 day')
 ```
 
 ### Create File View

--- a/synapsemonitor/__main__.py
+++ b/synapsemonitor/__main__.py
@@ -24,7 +24,8 @@ def monitor_cli(syn, args):
         syn_id=args.synapse_id,
         email_subject=args.email_subject,
         users=args.users,
-        days=args.days,
+        value=args.value,
+        unit=args.unit,
     )
     action_results = actions.synapse_action(action_cls=email_action)
     ids = pd.DataFrame({"syn_id": action_results})
@@ -102,12 +103,21 @@ def build_parser():
         help="Sets the subject heading of the email sent out. (default: %(default)s)",
     )
     parser_monitor.add_argument(
-        "--days",
-        "-d",
-        metavar="days",
+        "--value",
+        "-v",
+        metavar="value",
         type=int,
         default=1,
-        help="Find modifications to File entities in the last N days. "
+        help="Find modifications to File entities in the last {value} {unit}. "
+        "(default: %(default)s)",
+    )
+    parser_monitor.add_argument(
+        "--unit",
+        "-t",
+        choices=["day","hour","minute"],
+        type=str,
+        default="day",
+        help="Find modifications to File entities in the last {value} {unit}. "
         "(default: %(default)s)",
     )
     parser_monitor.set_defaults(func=monitor_cli)

--- a/synapsemonitor/__main__.py
+++ b/synapsemonitor/__main__.py
@@ -184,19 +184,19 @@ def main():
 
     if args.days != 1:
         args.value = args.days
-        args.unit = 'day'
+        args.unit = "day"
     else:
         args.value = int(args.rate[0])
-        if args.rate[1] in ['days','hours']:
+        if args.rate[1] in ["days", "hours"]:
             args.unit = args.rate[1][0:-1]
-        elif args.rate[1] in ['day','hour']:
+        elif args.rate[1] in ["day", "hour"]:
             args.unit = args.rate[1]
         else:
             valid_units = ["day", "days", "hours", "hour"]
             raise ValueError(
                 f"'{args.rate[1]}' is not an accepted time unit. Accepted units: {valid_units}."
             )
-    
+
     args.func(syn, args)
 
 

--- a/synapsemonitor/__main__.py
+++ b/synapsemonitor/__main__.py
@@ -114,7 +114,7 @@ def build_parser():
     parser_monitor.add_argument(
         "--unit",
         "-t",
-        choices=["day","hour","minute"],
+        choices=["day", "hour", "minute"],
         type=str,
         default="day",
         help="Find modifications to File entities in the last {value} {unit}. "

--- a/synapsemonitor/__main__.py
+++ b/synapsemonitor/__main__.py
@@ -114,7 +114,7 @@ def build_parser():
     parser_monitor.add_argument(
         "--unit",
         "-t",
-        choices=["day", "hour", "minute"],
+        choices=["day", "hour"],
         type=str,
         default="day",
         help="Find modifications to File entities in the last {value} {unit}. "

--- a/synapsemonitor/__main__.py
+++ b/synapsemonitor/__main__.py
@@ -24,7 +24,7 @@ def monitor_cli(syn, args):
         syn_id=args.synapse_id,
         email_subject=args.email_subject,
         users=args.users,
-        rate = args.rate,
+        rate=args.rate,
     )
     action_results = actions.synapse_action(action_cls=email_action)
     ids = pd.DataFrame({"syn_id": action_results})

--- a/synapsemonitor/__main__.py
+++ b/synapsemonitor/__main__.py
@@ -24,8 +24,7 @@ def monitor_cli(syn, args):
         syn_id=args.synapse_id,
         email_subject=args.email_subject,
         users=args.users,
-        value=args.value,
-        unit=args.unit,
+        rate = args.rate,
     )
     action_results = actions.synapse_action(action_cls=email_action)
     ids = pd.DataFrame({"syn_id": action_results})
@@ -102,24 +101,14 @@ def build_parser():
         default="New Synapse Files",
         help="Sets the subject heading of the email sent out. (default: %(default)s)",
     )
-    timing_group = parser_monitor.add_mutually_exclusive_group()
-    timing_group.add_argument(
-        "--days",
-        "-d",
-        metavar="days",
-        type=int,
-        default=1,
-        help="Find modifications to File entities in the last N days. "
-        "(default: %(default)s)",
-    )
-    timing_group.add_argument(
+    parser_monitor.add_argument(
         "--rate",
         "-r",
-        nargs=2,
-        metavar=("value", "unit"),
-        default=(1, "day"),
+        metavar="rate",
+        type=str,
+        default="1 day",
         help="Find modifications to File entities in the last {value} {unit}. "
-        "(default: %(default)s)",
+        "(default: '%(default)s')",
     )
     parser_monitor.set_defaults(func=monitor_cli)
 
@@ -181,21 +170,6 @@ def main():
     logging.basicConfig(level=numeric_level)
 
     syn = synapse_login(synapse_config=args.synapse_config)
-
-    if args.days != 1:
-        args.value = args.days
-        args.unit = "day"
-    else:
-        args.value = int(args.rate[0])
-        if args.rate[1] in ["days", "hours"]:
-            args.unit = args.rate[1][0:-1]
-        elif args.rate[1] in ["day", "hour"]:
-            args.unit = args.rate[1]
-        else:
-            valid_units = ["day", "days", "hours", "hour"]
-            raise ValueError(
-                f"'{args.rate[1]}' is not an accepted time unit. Accepted units: {valid_units}."
-            )
 
     args.func(syn, args)
 

--- a/synapsemonitor/actions.py
+++ b/synapsemonitor/actions.py
@@ -10,11 +10,12 @@ class SynapseAction(ABC):
     """Base synapse action class"""
 
     def __init__(
-        self, syn: Synapse, syn_id: str, days: int = 1, verbose: bool = False
+        self, syn: Synapse, syn_id: str, value: int = 1, unit: str = 'day', verbose: bool = False
     ) -> None:
         self.syn = syn
         self.syn_id = syn_id
-        self.days = days
+        self.value = value
+        self.unit = unit
         self.verbose = verbose
 
     @abstractmethod
@@ -24,7 +25,7 @@ class SynapseAction(ABC):
     def action(self):
         """Do action on list modified entities"""
         modified_entities = monitor.find_modified_entities(
-            syn=self.syn, syn_id=self.syn_id, days=self.days
+            syn=self.syn, syn_id=self.syn_id, value=self.value, unit=self.unit
         )
         action_result = self._action(modified_entities)
         if self.verbose:
@@ -39,14 +40,15 @@ class EmailAction(SynapseAction):
         self,
         syn: Synapse,
         syn_id: str,
-        days: int = 1,
+        value: int = 1,
+        unit: str = 'day',
         verbose: bool = False,
         users: list = None,
         email_subject: str = "New Synapse Files",
     ):
         self.users = users
         self.email_subject = email_subject
-        super().__init__(syn=syn, syn_id=syn_id, days=days, verbose=verbose)
+        super().__init__(syn=syn, syn_id=syn_id, value=value, unit=unit, verbose=verbose)
 
     def _action(self, modified_entities: list) -> list:
         # get user ids

--- a/synapsemonitor/actions.py
+++ b/synapsemonitor/actions.py
@@ -13,14 +13,12 @@ class SynapseAction(ABC):
         self,
         syn: Synapse,
         syn_id: str,
-        value: int = 1,
-        unit: str = "day",
+        rate: str = "1 day", 
         verbose: bool = False,
     ) -> None:
         self.syn = syn
         self.syn_id = syn_id
-        self.value = value
-        self.unit = unit
+        self.rate = rate
         self.verbose = verbose
 
     @abstractmethod
@@ -30,7 +28,7 @@ class SynapseAction(ABC):
     def action(self):
         """Do action on list modified entities"""
         modified_entities = monitor.find_modified_entities(
-            syn=self.syn, syn_id=self.syn_id, value=self.value, unit=self.unit
+            syn=self.syn, syn_id=self.syn_id, rate=self.rate
         )
         action_result = self._action(modified_entities)
         if self.verbose:
@@ -45,8 +43,7 @@ class EmailAction(SynapseAction):
         self,
         syn: Synapse,
         syn_id: str,
-        value: int = 1,
-        unit: str = "day",
+        rate: str = "1 day",
         verbose: bool = False,
         users: list = None,
         email_subject: str = "New Synapse Files",
@@ -54,7 +51,7 @@ class EmailAction(SynapseAction):
         self.users = users
         self.email_subject = email_subject
         super().__init__(
-            syn=syn, syn_id=syn_id, value=value, unit=unit, verbose=verbose
+            syn=syn, syn_id=syn_id, rate=rate, verbose=verbose
         )
 
     def _action(self, modified_entities: list) -> list:

--- a/synapsemonitor/actions.py
+++ b/synapsemonitor/actions.py
@@ -13,7 +13,7 @@ class SynapseAction(ABC):
         self,
         syn: Synapse,
         syn_id: str,
-        rate: str = "1 day", 
+        rate: str = "1 day",
         verbose: bool = False,
     ) -> None:
         self.syn = syn
@@ -50,9 +50,7 @@ class EmailAction(SynapseAction):
     ):
         self.users = users
         self.email_subject = email_subject
-        super().__init__(
-            syn=syn, syn_id=syn_id, rate=rate, verbose=verbose
-        )
+        super().__init__(syn=syn, syn_id=syn_id, rate=rate, verbose=verbose)
 
     def _action(self, modified_entities: list) -> list:
         # get user ids

--- a/synapsemonitor/actions.py
+++ b/synapsemonitor/actions.py
@@ -10,7 +10,12 @@ class SynapseAction(ABC):
     """Base synapse action class"""
 
     def __init__(
-        self, syn: Synapse, syn_id: str, value: int = 1, unit: str = 'day', verbose: bool = False
+        self,
+        syn: Synapse,
+        syn_id: str,
+        value: int = 1,
+        unit: str = "day",
+        verbose: bool = False,
     ) -> None:
         self.syn = syn
         self.syn_id = syn_id
@@ -41,14 +46,16 @@ class EmailAction(SynapseAction):
         syn: Synapse,
         syn_id: str,
         value: int = 1,
-        unit: str = 'day',
+        unit: str = "day",
         verbose: bool = False,
         users: list = None,
         email_subject: str = "New Synapse Files",
     ):
         self.users = users
         self.email_subject = email_subject
-        super().__init__(syn=syn, syn_id=syn_id, value=value, unit=unit, verbose=verbose)
+        super().__init__(
+            syn=syn, syn_id=syn_id, value=value, unit=unit, verbose=verbose
+        )
 
     def _action(self, modified_entities: list) -> list:
         # get user ids

--- a/synapsemonitor/monitor.py
+++ b/synapsemonitor/monitor.py
@@ -69,46 +69,57 @@ def _render_fileview(
     return viewdf
 
 
-def _find_modified_entities_fileview(syn: Synapse, syn_id: str, days: int = 1) -> list:
-    """Finds entities scoped in a fileview modified in the past N number of days
+def _find_modified_entities_fileview(syn: Synapse, syn_id: str, value: int = 1, unit: str = "day") -> list:
+    """Finds entities scoped in a fileview modified in the past {value} {unit}
 
     Args:
         syn: Synapse connection
         syn_id: Synapse Fileview Id
-        days: N number of days
+        value: number of time units
+        unit: time unit
 
     Returns:
         List of synapse ids
     """
     # Update the view
     # _force_update_view(syn, view_id)
+
     query = (
         f"select id from {syn_id} where "
-        f"modifiedOn > unix_timestamp(NOW() - INTERVAL {days} DAY)*1000"
+        f"modifiedOn > unix_timestamp(NOW() - INTERVAL {value} {unit})*1000"
     )
     results = syn.tableQuery(query)
     resultsdf = results.asDataFrame()
     return resultsdf["id"].tolist()
 
 
-def _find_modified_entities_file(syn: Synapse, syn_id: str, days: int = 1) -> list:
-    """Determines if entity was modified in the past N number of days
+def _find_modified_entities_file(syn: Synapse, syn_id: str, value: int = 1, unit: str = "day") -> list:
+    """Determines if entity was modified in the past {value} {unit}.
+    Note: entity modifiedOn returns UTC time
 
     Args:
         syn: Synapse connection
         syn_id: Synapse File Id
-        days: N number of days
+        value: number of time units
+        unit: time unit
 
     Returns:
         List of synapse ids
     """
     entity = syn.get(syn_id, downloadFile=False)
-    # Entity modified on returns UTC time
-    utc_mod = datetime.strptime(entity["modifiedOn"], "%Y-%m-%dT%H:%M:%S.%fZ").replace(
-        tzinfo=tz.tzutc()
-    )
-    utc_now = datetime.now().replace(tzinfo=tz.tzutc())
-    if utc_mod > utc_now - timedelta(days=days):
+    utc_mod = datetime.strptime(entity["modifiedOn"], "%Y-%m-%dT%H:%M:%S.%fZ")
+    utc_now = datetime.utcnow()
+
+    if unit == "day":
+        td = timedelta(days=value)
+    elif unit == "hour":
+        td = timedelta(hours=value)
+    elif unit == "minute":
+        td = timedelta(minutes=value)
+    else:
+        raise ValueError(f"'{unit}' is not an accepted time unit. Accepted units are 'day', 'hour', 'minute'.")
+
+    if utc_mod > utc_now - td:
         return [syn_id]
     return []
 
@@ -178,13 +189,14 @@ def _traverse_root(
     return synid_desc
 
 
-def _find_modified_entities_container(syn: Synapse, syn_id: str, days: int = 1) -> list:
-    """Finds entities in a folder or project modified in the past N number of days
+def _find_modified_entities_container(syn: Synapse, syn_id: str, value: int = 1, unit: str = "day") -> list:
+    """Finds entities in a folder or project modified in the past {value} {unit}
 
     Args:
         syn: Synapse connection
         syn_id: Synapse Folder or Project Id
-        days: N number of days
+        value: number of time units
+        unit: time unit
 
     Returns:
         List of synapse ids
@@ -193,7 +205,7 @@ def _find_modified_entities_container(syn: Synapse, syn_id: str, days: int = 1) 
     syn_id_children = _traverse_root(syn, syn_id)
 
     for syn_id_child in syn_id_children:
-        syn_id_res = _find_modified_entities_file(syn, syn_id_child, days)
+        syn_id_res = _find_modified_entities_file(syn, syn_id_child, value, unit)
         if syn_id_res:
             syn_id_mod.extend(syn_id_res)
 
@@ -231,24 +243,25 @@ def _get_user_ids(syn: Synapse, users: list = None):
     return user_ids
 
 
-def find_modified_entities(syn: Synapse, syn_id: str, days: int) -> list:
+def find_modified_entities(syn: Synapse, syn_id: str, value: int = 1, unit: str = "day") -> list:
     """Find modified entities based on the type of the input
 
     Args:
         syn: Synapse connection
         syn_id: Synapse Entity Id
-        days: N number of days
+        value: number of time units
+        unit: time unit
 
     Returns:
         List of synapse ids
     """
     entity = syn.get(syn_id, downloadFile=False)
     if isinstance(entity, synapseclient.EntityViewSchema):
-        return _find_modified_entities_fileview(syn=syn, syn_id=syn_id, days=days)
+        return _find_modified_entities_fileview(syn=syn, syn_id=syn_id, value=value, unit=unit)
     elif isinstance(entity, (synapseclient.File, synapseclient.Schema)):
-        return _find_modified_entities_file(syn=syn, syn_id=syn_id, days=days)
+        return _find_modified_entities_file(syn=syn, syn_id=syn_id, value=value, unit=unit)
     elif isinstance(entity, (synapseclient.Folder, synapseclient.Project)):
-        return _find_modified_entities_container(syn=syn, syn_id=syn_id, days=days)
+        return _find_modified_entities_container(syn=syn, syn_id=syn_id, value=value, unit=unit)
     else:
         raise ValueError(f"{type(entity)} not supported")
 
@@ -258,7 +271,8 @@ def monitoring(
     syn_id: str,
     users: list = None,
     email_subject: str = "New Synapse Files",
-    days: int = 1,
+    value: int = 1,
+    unit: str = 'day',
 ) -> pd.DataFrame:
     """Monitor the modifications of an entity scoped by a Fileview.
 
@@ -269,13 +283,14 @@ def monitoring(
                If empty, defaults to current logged in Synapse user.
         email_subject: Sets the subject heading of the email sent out.
                        (default: 'New Synapse Files')
-        days: Find modifications in the last N days (default: 1)
+        value: number of time units
+        unit: time unit
 
     Returns:
-        Dataframe with files modified within last N days
+        Dataframe with files modified within past {value} {unit}
     """
     # get dataframe of files
-    modified_entities = find_modified_entities(syn=syn, syn_id=syn_id, days=days)
+    modified_entities = find_modified_entities(syn=syn, syn_id=syn_id, value=value, unit=unit)
     # Filter out projects and folders
     logging.info(f"Total number of entities = {len(modified_entities)}")
 

--- a/synapsemonitor/monitor.py
+++ b/synapsemonitor/monitor.py
@@ -252,9 +252,7 @@ def _get_user_ids(syn: Synapse, users: list = None):
     return user_ids
 
 
-def find_modified_entities(
-    syn: Synapse, syn_id: str, rate: str = "1 day"
-) -> list:
+def find_modified_entities(syn: Synapse, syn_id: str, rate: str = "1 day") -> list:
     """Find modified entities based on the type of the input
 
     Args:
@@ -267,7 +265,7 @@ def find_modified_entities(
         List of synapse ids
     """
     # get value and time unit from rate
-    [value, unit] = parse_rate(rate = rate)
+    [value, unit] = parse_rate(rate=rate)
 
     entity = syn.get(syn_id, downloadFile=False)
     if isinstance(entity, synapseclient.EntityViewSchema):
@@ -286,8 +284,9 @@ def find_modified_entities(
         raise ValueError(f"{type(entity)} not supported")
 
 
-def parse_rate(rate: str, 
-    valid_units: typing.List[str] = ["day", "days", "hour", "hours"]) -> list:
+def parse_rate(
+    rate: str, valid_units: typing.List[str] = ["day", "days", "hour", "hours"]
+) -> list:
     """Parse value and time unit from rate string.
 
     Args:
@@ -305,10 +304,11 @@ def parse_rate(rate: str,
         )
 
     if unit in ["days", "hours"]:
-            unit = unit[0:-1]
+        unit = unit[0:-1]
     value = int(value)
 
     return [value, unit]
+
 
 def monitoring(
     syn: Synapse,
@@ -333,9 +333,7 @@ def monitoring(
     """
 
     # get dataframe of files
-    modified_entities = find_modified_entities(
-        syn=syn, syn_id=syn_id, rate=rate
-    )
+    modified_entities = find_modified_entities(syn=syn, syn_id=syn_id, rate=rate)
     # Filter out projects and folders
     logging.info(f"Total number of entities = {len(modified_entities)}")
 

--- a/synapsemonitor/monitor.py
+++ b/synapsemonitor/monitor.py
@@ -110,6 +110,13 @@ def _find_modified_entities_file(
     Returns:
         List of synapse ids
     """
+
+    valid_units = ["day", "hour", "minute"]
+    if unit not in valid_units:
+        raise ValueError(
+            f"'{unit}' is not an accepted time unit. Accepted units: {valid_units}."
+        )
+
     entity = syn.get(syn_id, downloadFile=False)
     utc_mod = datetime.strptime(entity["modifiedOn"], "%Y-%m-%dT%H:%M:%S.%fZ")
     utc_now = datetime.utcnow()
@@ -120,10 +127,6 @@ def _find_modified_entities_file(
         td = timedelta(hours=value)
     elif unit == "minute":
         td = timedelta(minutes=value)
-    else:
-        raise ValueError(
-            f"'{unit}' is not an accepted time unit. Accepted units are 'day', 'hour', 'minute'."
-        )
 
     if utc_mod > utc_now - td:
         return [syn_id]

--- a/synapsemonitor/monitor.py
+++ b/synapsemonitor/monitor.py
@@ -69,7 +69,9 @@ def _render_fileview(
     return viewdf
 
 
-def _find_modified_entities_fileview(syn: Synapse, syn_id: str, value: int = 1, unit: str = "day") -> list:
+def _find_modified_entities_fileview(
+    syn: Synapse, syn_id: str, value: int = 1, unit: str = "day"
+) -> list:
     """Finds entities scoped in a fileview modified in the past {value} {unit}
 
     Args:
@@ -93,7 +95,9 @@ def _find_modified_entities_fileview(syn: Synapse, syn_id: str, value: int = 1, 
     return resultsdf["id"].tolist()
 
 
-def _find_modified_entities_file(syn: Synapse, syn_id: str, value: int = 1, unit: str = "day") -> list:
+def _find_modified_entities_file(
+    syn: Synapse, syn_id: str, value: int = 1, unit: str = "day"
+) -> list:
     """Determines if entity was modified in the past {value} {unit}.
     Note: entity modifiedOn returns UTC time
 
@@ -117,7 +121,9 @@ def _find_modified_entities_file(syn: Synapse, syn_id: str, value: int = 1, unit
     elif unit == "minute":
         td = timedelta(minutes=value)
     else:
-        raise ValueError(f"'{unit}' is not an accepted time unit. Accepted units are 'day', 'hour', 'minute'.")
+        raise ValueError(
+            f"'{unit}' is not an accepted time unit. Accepted units are 'day', 'hour', 'minute'."
+        )
 
     if utc_mod > utc_now - td:
         return [syn_id]
@@ -189,7 +195,9 @@ def _traverse_root(
     return synid_desc
 
 
-def _find_modified_entities_container(syn: Synapse, syn_id: str, value: int = 1, unit: str = "day") -> list:
+def _find_modified_entities_container(
+    syn: Synapse, syn_id: str, value: int = 1, unit: str = "day"
+) -> list:
     """Finds entities in a folder or project modified in the past {value} {unit}
 
     Args:
@@ -243,7 +251,9 @@ def _get_user_ids(syn: Synapse, users: list = None):
     return user_ids
 
 
-def find_modified_entities(syn: Synapse, syn_id: str, value: int = 1, unit: str = "day") -> list:
+def find_modified_entities(
+    syn: Synapse, syn_id: str, value: int = 1, unit: str = "day"
+) -> list:
     """Find modified entities based on the type of the input
 
     Args:
@@ -257,11 +267,17 @@ def find_modified_entities(syn: Synapse, syn_id: str, value: int = 1, unit: str 
     """
     entity = syn.get(syn_id, downloadFile=False)
     if isinstance(entity, synapseclient.EntityViewSchema):
-        return _find_modified_entities_fileview(syn=syn, syn_id=syn_id, value=value, unit=unit)
+        return _find_modified_entities_fileview(
+            syn=syn, syn_id=syn_id, value=value, unit=unit
+        )
     elif isinstance(entity, (synapseclient.File, synapseclient.Schema)):
-        return _find_modified_entities_file(syn=syn, syn_id=syn_id, value=value, unit=unit)
+        return _find_modified_entities_file(
+            syn=syn, syn_id=syn_id, value=value, unit=unit
+        )
     elif isinstance(entity, (synapseclient.Folder, synapseclient.Project)):
-        return _find_modified_entities_container(syn=syn, syn_id=syn_id, value=value, unit=unit)
+        return _find_modified_entities_container(
+            syn=syn, syn_id=syn_id, value=value, unit=unit
+        )
     else:
         raise ValueError(f"{type(entity)} not supported")
 
@@ -272,7 +288,7 @@ def monitoring(
     users: list = None,
     email_subject: str = "New Synapse Files",
     value: int = 1,
-    unit: str = 'day',
+    unit: str = "day",
 ) -> pd.DataFrame:
     """Monitor the modifications of an entity scoped by a Fileview.
 
@@ -290,7 +306,9 @@ def monitoring(
         Dataframe with files modified within past {value} {unit}
     """
     # get dataframe of files
-    modified_entities = find_modified_entities(syn=syn, syn_id=syn_id, value=value, unit=unit)
+    modified_entities = find_modified_entities(
+        syn=syn, syn_id=syn_id, value=value, unit=unit
+    )
     # Filter out projects and folders
     logging.info(f"Total number of entities = {len(modified_entities)}")
 

--- a/synapsemonitor/monitor.py
+++ b/synapsemonitor/monitor.py
@@ -111,7 +111,7 @@ def _find_modified_entities_file(
         List of synapse ids
     """
 
-    valid_units = ["day", "hour", "minute"]
+    valid_units = ["day", "hour"]
     if unit not in valid_units:
         raise ValueError(
             f"'{unit}' is not an accepted time unit. Accepted units: {valid_units}."
@@ -125,8 +125,6 @@ def _find_modified_entities_file(
         td = timedelta(days=value)
     elif unit == "hour":
         td = timedelta(hours=value)
-    elif unit == "minute":
-        td = timedelta(minutes=value)
 
     if utc_mod > utc_now - td:
         return [syn_id]

--- a/synapsemonitor/monitor.py
+++ b/synapsemonitor/monitor.py
@@ -253,7 +253,7 @@ def _get_user_ids(syn: Synapse, users: list = None):
 
 
 def find_modified_entities(
-    syn: Synapse, syn_id: str, value: int = 1, unit: str = "day"
+    syn: Synapse, syn_id: str, rate: str = "1 day"
 ) -> list:
     """Find modified entities based on the type of the input
 
@@ -266,6 +266,9 @@ def find_modified_entities(
     Returns:
         List of synapse ids
     """
+    # get value and time unit from rate
+    [value, unit] = parse_rate(rate = rate)
+
     entity = syn.get(syn_id, downloadFile=False)
     if isinstance(entity, synapseclient.EntityViewSchema):
         return _find_modified_entities_fileview(
@@ -283,13 +286,36 @@ def find_modified_entities(
         raise ValueError(f"{type(entity)} not supported")
 
 
+def parse_rate(rate: str, 
+    valid_units: typing.List[str] = ["day", "days", "hour", "hours"]) -> list:
+    """Parse value and time unit from rate string.
+
+    Args:
+        rate (str): string specifying rate at which to monitor
+
+    Returns:
+        [int, str]: integer value and time unit of rate
+    """
+
+    [value, unit] = rate.split(" ")
+
+    if unit not in valid_units:
+        raise ValueError(
+            f"'{unit}' is not an accepted time unit. Accepted units: {valid_units}."
+        )
+
+    if unit in ["days", "hours"]:
+            unit = unit[0:-1]
+    value = int(value)
+
+    return [value, unit]
+
 def monitoring(
     syn: Synapse,
     syn_id: str,
     users: list = None,
     email_subject: str = "New Synapse Files",
-    value: int = 1,
-    unit: str = "day",
+    rate: str = "1 day",
 ) -> pd.DataFrame:
     """Monitor the modifications of an entity scoped by a Fileview.
 
@@ -300,15 +326,15 @@ def monitoring(
                If empty, defaults to current logged in Synapse user.
         email_subject: Sets the subject heading of the email sent out.
                        (default: 'New Synapse Files')
-        value: number of time units
-        unit: time unit
+        rate: String specifying rate
 
     Returns:
         Dataframe with files modified within past {value} {unit}
     """
+
     # get dataframe of files
     modified_entities = find_modified_entities(
-        syn=syn, syn_id=syn_id, value=value, unit=unit
+        syn=syn, syn_id=syn_id, rate=rate
     )
     # Filter out projects and folders
     logging.info(f"Total number of entities = {len(modified_entities)}")

--- a/test/test_monitor.py
+++ b/test/test_monitor.py
@@ -66,11 +66,11 @@ class TestModifiedEntitiesFileView:
             # patch.object(monitor, "_render_fileview",
             #              return_value=self.expecteddf) as patch_render:
             modified_list = monitor._find_modified_entities_fileview(
-                self.syn, "syn44444", days=2
+                self.syn, "syn44444", value=2, unit='day'
             )
             patch_q.assert_called_once_with(
                 "select id from syn44444 where "
-                "modifiedOn > unix_timestamp(NOW() - INTERVAL 2 DAY)*1000"
+                "modifiedOn > unix_timestamp(NOW() - INTERVAL 2 day)*1000"
             )
             patch_asdf.assert_called_once_with()
             assert modified_list == ["syn23333"]
@@ -184,7 +184,7 @@ class TestModifiedContainer:
             patch.object(monitor, "_find_modified_entities_file",
                          return_value=[self.folder["id"]]) as patch_child:
             modified_list = monitor._find_modified_entities_container(
-                self.syn, self.folder["id"], days=self.days
+                self.syn, self.folder["id"], value=self.days, unit="day"
             )
             patch_get.assert_called()
             patch_child.assert_called()
@@ -198,7 +198,7 @@ class TestModifiedContainer:
             patch.object(monitor, "_find_modified_entities_file",
                          return_value=[self.project["id"]]) as patch_child:
             modified_list = monitor._find_modified_entities_container(
-                self.syn, self.project["id"], days=self.days
+                self.syn, self.project["id"], value=self.days, unit="day"
             )
             patch_get.assert_called()
             patch_child.assert_called()
@@ -214,7 +214,7 @@ class TestModifiedContainer:
             patch.object(monitor, "_find_modified_entities_file",
                          return_value=[]) as patch_child:
             modified_list = monitor._find_modified_entities_container(
-                self.syn, "syn234", days=self.days
+                self.syn, "syn234", value=self.days, unit='day'
             )
             patch_get.assert_called()
             patch_child.assert_called()
@@ -230,7 +230,7 @@ class TestModifiedContainer:
             patch.object(monitor, "_find_modified_entities_file",
                          return_value=[]) as patch_child:
             modified_list = monitor._find_modified_entities_container(
-                self.syn, "syn234", days=self.days
+                self.syn, "syn234", value=self.days, unit='day'
             )
             patch_get.assert_called()
             patch_child.assert_called()
@@ -245,7 +245,7 @@ def test__find_modified_entities_file_modified():
     )
     entity = File("test", "syn234", modifiedOn=date_mod)
     with patch.object(syn, "get", return_value=entity) as patch_get:
-        modified_list = monitor._find_modified_entities_file(syn, "syn234", days=1)
+        modified_list = monitor._find_modified_entities_file(syn, "syn234", value=1, unit='day')
         patch_get.assert_called_once_with("syn234", downloadFile=False)
         assert modified_list == ["syn234"]
 
@@ -258,7 +258,7 @@ def test__find_modified_entities_file_none():
     date_mod = old_modified.replace(tzinfo=tz.tzutc()).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
     entity = File("test", "syn234", modifiedOn=date_mod)
     with patch.object(syn, "get", return_value=entity) as patch_get:
-        modified_list = monitor._find_modified_entities_file(syn, "syn234", days=1)
+        modified_list = monitor._find_modified_entities_file(syn, "syn234", value=1, unit='day')
         patch_get.assert_called_once_with("syn234", downloadFile=False)
         assert modified_list == []
 
@@ -294,7 +294,7 @@ def test_find_modified_entities_unsupported(entity, entity_type):
     with pytest.raises(
         ValueError, match=f".+synapseclient.entity.{entity_type}'> not supported"
     ), patch.object(syn, "get", return_value=entity):
-        monitor.find_modified_entities(syn=syn, syn_id="syn12345", days=1)
+        monitor.find_modified_entities(syn=syn, syn_id="syn12345", value=1, unit="day")
 
 
 def test_find_modified_entities_supported():
@@ -305,7 +305,7 @@ def test_find_modified_entities_supported():
     with patch.object(syn, "get", return_value=entity) as patch_get, patch.object(
         monitor, "_find_modified_entities_fileview", return_value=empty
     ) as patch_mod:
-        value = monitor.find_modified_entities(syn=syn, syn_id="syn12345", days=1)
+        value = monitor.find_modified_entities(syn=syn, syn_id="syn12345", value=1, unit="day")
         patch_get.assert_called_once_with("syn12345", downloadFile=False)
         patch_mod.assert_called_once()
         assert empty.equals(value)
@@ -332,9 +332,10 @@ class TestMonitoring:
                 "syn12345",
                 users=["2222", "fooo"],
                 email_subject="new subject",
-                days=15,
+                value=15,
+                unit="day",
             )
-            patch_find.assert_called_once_with(syn=self.syn, syn_id="syn12345", days=15)
+            patch_find.assert_called_once_with(syn=self.syn, syn_id="syn12345", value=15, unit="day")
             patch_get_user.assert_called_once_with(self.syn, ["2222", "fooo"])
             patch_send.assert_called_once_with(
                 [111], "new subject", "syn2222, syn33333", contentType="text/html"

--- a/test/test_monitor.py
+++ b/test/test_monitor.py
@@ -314,7 +314,7 @@ def test_find_modified_entities_unsupported(entity, entity_type):
     with pytest.raises(
         ValueError, match=f".+synapseclient.entity.{entity_type}'> not supported"
     ), patch.object(syn, "get", return_value=entity):
-        monitor.find_modified_entities(syn=syn, syn_id="syn12345", value=1, unit="day")
+        monitor.find_modified_entities(syn=syn, syn_id="syn12345", rate="1 day")
 
 
 def test_find_modified_entities_supported():
@@ -325,7 +325,7 @@ def test_find_modified_entities_supported():
     with patch.object(syn, "get", return_value=entity) as patch_get, patch.object(
         monitor, "_find_modified_entities_fileview", return_value=empty
     ) as patch_mod:
-        value = monitor.find_modified_entities(syn=syn, syn_id="syn12345", value=1, unit="day")
+        value = monitor.find_modified_entities(syn=syn, syn_id="syn12345", rate="1 day")
         patch_get.assert_called_once_with("syn12345", downloadFile=False)
         patch_mod.assert_called_once()
         assert empty.equals(value)
@@ -352,10 +352,9 @@ class TestMonitoring:
                 "syn12345",
                 users=["2222", "fooo"],
                 email_subject="new subject",
-                value=15,
-                unit="day",
+                rate="15 day",
             )
-            patch_find.assert_called_once_with(syn=self.syn, syn_id="syn12345", value=15, unit="day")
+            patch_find.assert_called_once_with(syn=self.syn, syn_id="syn12345", rate="15 day")
             patch_get_user.assert_called_once_with(self.syn, ["2222", "fooo"])
             patch_send.assert_called_once_with(
                 [111], "new subject", "syn2222, syn33333", contentType="text/html"

--- a/test/test_monitor.py
+++ b/test/test_monitor.py
@@ -85,8 +85,8 @@ class TestModifiedContainer:
     def setup_method(self):
         self.syn = Mock()
         self.days = 1
-        self.now = datetime.now().replace(tzinfo=tz.tzutc()).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
-        self.past = (datetime.now().replace(tzinfo=tz.tzutc()) - timedelta(days=self.days+1)).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+        self.now = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+        self.past = (datetime.utcnow() - timedelta(days=self.days+1)).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
         self.project = Project(name="test_project", id = "syn0", modifiedOn=self.now, parentId = "syn00")
         self.folder = Folder(name="test_folder", id = "syn1", modifiedOn=self.now, parentId = "syn0")
         self.file = File(name="test_file", id = "syn2", modifiedOn=self.now, parentId = "syn1")
@@ -240,9 +240,7 @@ class TestModifiedContainer:
 def test__find_modified_entities_file_modified():
     """Patch finding modified entities no modified"""
     syn = Mock()
-    date_mod = (
-        datetime.now().replace(tzinfo=tz.tzutc()).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
-    )
+    date_mod = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ")
     entity = File("test", "syn234", modifiedOn=date_mod)
     with patch.object(syn, "get", return_value=entity) as patch_get:
         modified_list = monitor._find_modified_entities_file(syn, "syn234", value=1, unit='day')
@@ -264,7 +262,7 @@ def test__find_modified_entities_file_hour_modified():
 def test__find_modified_entities_file_hour_not_modified():
     """Patch finding no modified entities by hour"""
     syn = Mock()
-    date_mod = ((datetime.utcnow() - timedelta(hours=2)).strftime("%Y-%m-%dT%H:%M:%S.%fZ")) 
+    date_mod = (datetime.utcnow() - timedelta(hours=2)).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
     entity = File("test", "syn234", modifiedOn=date_mod)
     with patch.object(syn, "get", return_value=entity) as patch_get:
         modified_list = monitor._find_modified_entities_file(syn, "syn234", value=1, unit='hour')
@@ -275,7 +273,7 @@ def test__find_modified_entities_file_hour_not_modified():
 def test__find_modified_entities_file_minute_modified():
     """Patch finding modified entities by minute"""
     syn = Mock()
-    date_mod = (datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ"))
+    date_mod = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ")
     entity = File("test", "syn234", modifiedOn=date_mod)
     with patch.object(syn, "get", return_value=entity) as patch_get:
         modified_list = monitor._find_modified_entities_file(syn, "syn234", value=1, unit='minute')
@@ -286,7 +284,7 @@ def test__find_modified_entities_file_minute_modified():
 def test__find_modified_entities_file_minute_not_modified():
     """Patch finding no modified entities by minute"""
     syn = Mock()
-    date_mod = ((datetime.utcnow() - timedelta(minutes=2)).strftime("%Y-%m-%dT%H:%M:%S.%fZ")) 
+    date_mod = (datetime.utcnow() - timedelta(minutes=2)).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
     entity = File("test", "syn234", modifiedOn=date_mod)
     with patch.object(syn, "get", return_value=entity) as patch_get:
         modified_list = monitor._find_modified_entities_file(syn, "syn234", value=1, unit='minute')
@@ -298,8 +296,8 @@ def test__find_modified_entities_file_none():
     """Patch finding modified entities no modified"""
     syn = Mock()
     # create a modified date that is in the past
-    old_modified = datetime.now() - timedelta(days=3)
-    date_mod = old_modified.replace(tzinfo=tz.tzutc()).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+    old_modified = datetime.utcnow() - timedelta(days=3)
+    date_mod = old_modified.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
     entity = File("test", "syn234", modifiedOn=date_mod)
     with patch.object(syn, "get", return_value=entity) as patch_get:
         modified_list = monitor._find_modified_entities_file(syn, "syn234", value=1, unit='day')

--- a/test/test_monitor.py
+++ b/test/test_monitor.py
@@ -250,6 +250,50 @@ def test__find_modified_entities_file_modified():
         assert modified_list == ["syn234"]
 
 
+def test__find_modified_entities_file_hour_modified():
+    """Patch finding modified entities by hour"""
+    syn = Mock()
+    date_mod = (datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ"))
+    entity = File("test", "syn234", modifiedOn=date_mod)
+    with patch.object(syn, "get", return_value=entity) as patch_get:
+        modified_list = monitor._find_modified_entities_file(syn, "syn234", value=1, unit='hour')
+        patch_get.assert_called_once_with("syn234", downloadFile=False)
+        assert modified_list == ["syn234"]
+
+
+def test__find_modified_entities_file_hour_not_modified():
+    """Patch finding no modified entities by hour"""
+    syn = Mock()
+    date_mod = ((datetime.utcnow() - timedelta(hours=2)).strftime("%Y-%m-%dT%H:%M:%S.%fZ")) 
+    entity = File("test", "syn234", modifiedOn=date_mod)
+    with patch.object(syn, "get", return_value=entity) as patch_get:
+        modified_list = monitor._find_modified_entities_file(syn, "syn234", value=1, unit='hour')
+        patch_get.assert_called_once_with("syn234", downloadFile=False)
+        assert modified_list == []
+
+
+def test__find_modified_entities_file_minute_modified():
+    """Patch finding modified entities by minute"""
+    syn = Mock()
+    date_mod = (datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ"))
+    entity = File("test", "syn234", modifiedOn=date_mod)
+    with patch.object(syn, "get", return_value=entity) as patch_get:
+        modified_list = monitor._find_modified_entities_file(syn, "syn234", value=1, unit='minute')
+        patch_get.assert_called_once_with("syn234", downloadFile=False)
+        assert modified_list == ["syn234"]
+
+
+def test__find_modified_entities_file_minute_not_modified():
+    """Patch finding no modified entities by minute"""
+    syn = Mock()
+    date_mod = ((datetime.utcnow() - timedelta(minutes=2)).strftime("%Y-%m-%dT%H:%M:%S.%fZ")) 
+    entity = File("test", "syn234", modifiedOn=date_mod)
+    with patch.object(syn, "get", return_value=entity) as patch_get:
+        modified_list = monitor._find_modified_entities_file(syn, "syn234", value=1, unit='minute')
+        patch_get.assert_called_once_with("syn234", downloadFile=False)
+        assert modified_list == []
+
+
 def test__find_modified_entities_file_none():
     """Patch finding modified entities no modified"""
     syn = Mock()

--- a/test/test_monitor.py
+++ b/test/test_monitor.py
@@ -270,28 +270,6 @@ def test__find_modified_entities_file_hour_not_modified():
         assert modified_list == []
 
 
-def test__find_modified_entities_file_minute_modified():
-    """Patch finding modified entities by minute"""
-    syn = Mock()
-    date_mod = datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ")
-    entity = File("test", "syn234", modifiedOn=date_mod)
-    with patch.object(syn, "get", return_value=entity) as patch_get:
-        modified_list = monitor._find_modified_entities_file(syn, "syn234", value=1, unit='minute')
-        patch_get.assert_called_once_with("syn234", downloadFile=False)
-        assert modified_list == ["syn234"]
-
-
-def test__find_modified_entities_file_minute_not_modified():
-    """Patch finding no modified entities by minute"""
-    syn = Mock()
-    date_mod = (datetime.utcnow() - timedelta(minutes=2)).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
-    entity = File("test", "syn234", modifiedOn=date_mod)
-    with patch.object(syn, "get", return_value=entity) as patch_get:
-        modified_list = monitor._find_modified_entities_file(syn, "syn234", value=1, unit='minute')
-        patch_get.assert_called_once_with("syn234", downloadFile=False)
-        assert modified_list == []
-
-
 def test__find_modified_entities_file_none():
     """Patch finding modified entities no modified"""
     syn = Mock()


### PR DESCRIPTION
Fixes #25 

Allow user to specify value of time in the past to search for modified entities in days, hours, or minutes:

major changes
- adapt CLI to specify value and unit (default is still 1 day)
- adapt function parameters for value and unit input
- adapt detection of modified entities in a fileview and from the entity modifiedOn timestamp to time unit
- new tests for detecting changes by hour and minute

other changes
- use datetime.utcnow() to get current time in UTC directly